### PR TITLE
ingest version from new source, do not use at buildtime

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,7 +103,8 @@ pipeline {
       steps{
         script{
           env.EXT_RELEASE = sh(
-            script: ''' curl -sL https://download.foldingathome.org/js/fah-downloads.js | awk -F'(fahclient_|_amd64.deb)' '/debian-stable-64bit/ {print $2;exit}' ''',
+            script: ''' curl -sL https://download.foldingathome.org/releases.py?series=7.6 | jq -r '.[] | select(.title=="64bit Linux") | .groups[0].files[0].filename' | awk -F'(fahclient_|_amd64.deb)' '{print $2}'
+ ''',
             returnStdout: true).trim()
             env.RELEASE_LINK = 'custom_command'
         }

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -3,7 +3,8 @@
 # jenkins variables
 project_name: docker-foldingathome
 external_type: na
-custom_version_command: "curl -sL https://download.foldingathome.org/js/fah-downloads.js | awk -F'(fahclient_|_amd64.deb)' '/debian-stable-64bit/ {print $2;exit}'"
+custom_version_command: |
+  curl -sL https://download.foldingathome.org/releases.py?series=7.6 | jq -r '.[] | select(.title=="64bit Linux") | .groups[0].files[0].filename' | awk -F'(fahclient_|_amd64.deb)' '{print $2}'
 release_type: stable
 release_tag: latest
 ls_branch: master


### PR DESCRIPTION
We will need to babysit the major version there is no way around this, but it looks like they do not change this for years.

This external trigger needs to be re-enabled after this builds. 
https://ci.linuxserver.io/job/External-Triggers/job/foldingathome-external-trigger/