### PR TITLE
Update version and artifact endpoint

### DIFF
--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -20,7 +20,7 @@ jobs:
           echo "**** External trigger running off of master branch. To disable this trigger, set a Github secret named \"PAUSE_EXTERNAL_TRIGGER_FOLDINGATHOME_MASTER\". ****"
           echo "External trigger running off of master branch. To disable this trigger, set a Github secret named \`PAUSE_EXTERNAL_TRIGGER_FOLDINGATHOME_MASTER\`" >> $GITHUB_STEP_SUMMARY
           echo "**** Retrieving external version ****"
-          EXT_RELEASE=$(curl -H 'Accept-Encoding: gzip' -fSsL --compressed https://download.foldingathome.org/releases.py | jq -r '.[] | select(.title=="64bit Linux") | .groups[0].files[0].filename' | awk -F'(fah-client_|_amd64.deb)' '{print $2}')
+          EXT_RELEASE=$(curl -s https://download.foldingathome.org/releases/public/fah-client/meta.json | jq -r '.[] | select((.package | contains("amd64.deb")) and (.package | contains("release"))) | .package' | awk -F'(fah-client_|_amd64.deb)' '{print $2}')
           if [ -z "${EXT_RELEASE}" ] || [ "${EXT_RELEASE}" == "null" ]; then
             echo "**** Can't retrieve external version, exiting ****"
             FAILURE_REASON="Can't retrieve external version for foldingathome branch master"

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN \
     intel-opencl-icd && \
   ln -s libOpenCL.so.1 /usr/lib/x86_64-linux-gnu/libOpenCL.so && \
   echo "**** install foldingathome ****" && \
-  download_url=$(curl -H 'Accept-Encoding: gzip' -fSsL --compressed https://download.foldingathome.org/releases.py | jq -r '.[] | select(.title=="64bit Linux") | .groups[].files[].url' | grep "fah-client" | grep -v "arm64" | grep "tar.bz2") && \
+  download_url="https://download.foldingathome.org/releases/public/fah-client/"$(curl -s https://download.foldingathome.org/releases/public/fah-client/meta.json | jq -r '.[] | select((.package | contains("debian")) and (.package | contains("release"))) | .package' | grep -v "arm64" | grep "tar.bz2") && \
   curl -o \
     /tmp/fah.tar.bz2 -L \
     ${download_url} && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -23,7 +23,7 @@ RUN \
     ocl-icd-libopencl1 && \
   ln -s libOpenCL.so.1 /usr/lib/aarch64-linux-gnu/libOpenCL.so && \
   echo "**** install foldingathome ****" && \
-  download_url=$(curl -H 'Accept-Encoding: gzip' -fSsL --compressed https://download.foldingathome.org/releases.py | jq -r '.[] | select(.title=="64bit Linux") | .groups[].files[].url' | grep "fah-client" | grep "arm64" | grep "tar.bz2") && \
+  download_url="https://download.foldingathome.org/releases/public/fah-client/"$(curl -s https://download.foldingathome.org/releases/public/fah-client/meta.json | jq -r '.[] | select((.package | contains("debian")) and (.package | contains("release"))) | .package' | grep "arm64" | grep "tar.bz2") && \
   curl -o \
     /tmp/fah.tar.bz2 -L \
     ${download_url} && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,7 +115,7 @@ pipeline {
       steps{
         script{
           env.EXT_RELEASE = sh(
-            script: ''' curl -H 'Accept-Encoding: gzip' -fSsL --compressed https://download.foldingathome.org/releases.py | jq -r '.[] | select(.title=="64bit Linux") | .groups[0].files[0].filename' | awk -F'(fah-client_|_amd64.deb)' '{print $2}' ''',
+            script: ''' curl -s https://download.foldingathome.org/releases/public/fah-client/meta.json | jq -r '.[] | select((.package | contains("amd64.deb")) and (.package | contains("release"))) | .package' | awk -F'(fah-client_|_amd64.deb)' '{print $2}' ''',
             returnStdout: true).trim()
             env.RELEASE_LINK = 'custom_command'
         }

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -3,7 +3,7 @@
 # jenkins variables
 project_name: docker-foldingathome
 external_type: na
-custom_version_command: "curl -H 'Accept-Encoding: gzip' -fSsL --compressed https://download.foldingathome.org/releases.py | jq -r '.[] | select(.title==\"64bit Linux\") | .groups[0].files[0].filename' | awk -F'(fah-client_|_amd64.deb)' '{print $2}'"
+custom_version_command: "curl -s https://download.foldingathome.org/releases/public/fah-client/meta.json | jq -r '.[] | select((.package | contains(\"amd64.deb\")) and (.package | contains(\"release\"))) | .package' | awk -F'(fah-client_|_amd64.deb)' '{print $2}'"
 release_type: stable
 release_tag: latest
 ls_branch: master


### PR DESCRIPTION
Folding at home changed their versioning and artifact listing again. They deprecated the py script that was used to get the latest releases for their website.

After a bunch of rabbit hole diving, I found that this is the new js script the website uses to get the latest releases: https://download.foldingathome.org/assets/app-ce1d461c.js

This PR parses the json file at https://download.foldingathome.org/releases/public/fah-client/meta.json to get the latest version and the artifact addresses. I hope it doesn't change again anytime soon.